### PR TITLE
removed extra code that was creating duplicates

### DIFF
--- a/lib/UI/Dialog/Backend/CDialog.pm
+++ b/lib/UI/Dialog/Backend/CDialog.pm
@@ -676,21 +676,6 @@ sub checklist {
       text => $self->make_kvt($args,$args->{'text'}),
     );
 
-  if ($args->{'list'}) {
-		$args->{'list'} = [ ' ', [' ', 1] ] unless ref($args->{'list'}) eq "ARRAY";
-		my ($item,$info);
-		while (@{$args->{'list'}}) {
-			$item = shift(@{$args->{'list'}});
-			$info = shift(@{$args->{'list'}});
-			$command .= ' "'.($item||' ').'" "'.($info->[0]||' ').'" "'.(($info->[1]) ? 'on' : 'off').'"';
-		}
-  }
-  else {
-		$args->{'items'} = [ ' ', ' ', 'off' ] unless ref($args->{'items'}) eq "ARRAY";
-		foreach my $item (@{$args->{'items'}}) {
-			$command .= ' "' . ($item|' ') . '"';
-		}
-  }
   my ($rv,$selected) = $self->command_array($command);
   $self->rs('null');
   my $this_rv;


### PR DESCRIPTION
When using terminal dialog (installed on Mac OS X via homebrew), I noticed that a "checklist" wound up with everything listed twice. Reviewing the code, it looks like there was some code that wasn't removed during some kind of refactor. Looking at the `menu` sub, I modified the `checklist` sub as appropriate. This removes code that was doing something with an "item" parameter, but this isn't referenced in the documentation anywhere, so I don't know if it's current.
